### PR TITLE
Add static landing page HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Postula Fácil</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/lucide@latest"></script>
+</head>
+<body class="min-h-screen bg-gradient-to-b from-slate-50 to-white text-slate-800">
+  <!-- NAVBAR -->
+  <header class="sticky top-0 z-40 backdrop-blur bg-white/70 border-b border-slate-200">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+      <a href="#" class="flex items-center gap-2">
+        <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-slate-900 text-white font-bold">PF</span>
+        <span class="font-semibold tracking-tight">Postula Fácil</span>
+      </a>
+      <nav class="hidden md:flex items-center gap-8 text-sm">
+        <a href="#servicios" class="hover:text-slate-900 text-slate-600">Servicios</a>
+        <a href="#pasos" class="hover:text-slate-900 text-slate-600">Cómo funciona</a>
+        <a href="#faq" class="hover:text-slate-900 text-slate-600">Preguntas</a>
+      </nav>
+      <a href="https://wa.me/51991963019?text=Hola%20vengo%20de%20la%20web%20Postula%20F%C3%A1cil%20y%20quiero%20asesor%C3%ADa%20para%20postular" target="_blank" class="inline-flex items-center gap-2 rounded-2xl bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 shadow-sm transition">
+        <i data-lucide="message-circle" class="h-4 w-4"></i>
+        WhatsApp
+      </a>
+    </div>
+  </header>
+
+  <!-- HERO -->
+  <section class="relative overflow-hidden">
+    <div class="absolute inset-0 -z-10">
+      <div class="absolute -top-24 -right-24 h-64 w-64 rounded-full bg-emerald-100 blur-3xl"></div>
+      <div class="absolute -bottom-24 -left-24 h-72 w-72 rounded-full bg-sky-100 blur-3xl"></div>
+    </div>
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-16 sm:py-24 grid lg:grid-cols-2 gap-10 items-center">
+      <div>
+        <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight text-slate-900 leading-tight">
+          ¿Quieres postular y no sabes cómo?
+        </h1>
+        <p class="mt-5 text-lg text-slate-600 max-w-xl">
+          Te acompaño paso a paso para presentar tu postulación <span class="font-semibold text-slate-800">sin errores</span> en convocatorias del Estado, colegios, ONGs y empresas. Atención 100% online para todo el Perú.
+        </p>
+        <div class="mt-8 flex flex-wrap gap-3">
+          <a href="https://wa.me/51991963019?text=Hola%20vengo%20de%20la%20web%20Postula%20F%C3%A1cil%20y%20quiero%20asesor%C3%ADa%20para%20postular" target="_blank" class="inline-flex items-center gap-2 rounded-2xl bg-emerald-600 hover:bg-emerald-700 text-white px-6 py-3 text-base shadow-md transition">
+            <i data-lucide="message-circle" class="h-5 w-5"></i>
+            Escríbeme por WhatsApp
+          </a>
+          <a href="#servicios" class="inline-flex items-center gap-2 rounded-2xl border border-slate-300 px-6 py-3 text-base text-slate-800 hover:bg-slate-50">
+            Ver servicios
+          </a>
+        </div>
+        <div class="mt-6 text-sm text-slate-500">
+          <p class="italic">“No garantizo el puesto; garantizo tu postulación correcta.”</p>
+        </div>
+      </div>
+      <div class="relative">
+        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div class="grid sm:grid-cols-2 gap-6">
+            <div class="flex items-start gap-3 rounded-2xl border border-slate-200 p-4">
+              <div class="shrink-0"><i data-lucide="check-circle-2" class="h-5 w-5 text-emerald-600"></i></div>
+              <div>
+                <p class="font-semibold text-slate-900">Revisión de requisitos</p>
+                <p class="text-sm text-slate-600">Verifico bases y formatos antes de enviar</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 rounded-2xl border border-slate-200 p-4">
+              <div class="shrink-0"><i data-lucide="file-text" class="h-5 w-5 text-sky-600"></i></div>
+              <div>
+                <p class="font-semibold text-slate-900">CV ordenado</p>
+                <p class="text-sm text-slate-600">Adaptado al formato solicitado</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 rounded-2xl border border-slate-200 p-4">
+              <div class="shrink-0"><i data-lucide="upload" class="h-5 w-5 text-orange-500"></i></div>
+              <div>
+                <p class="font-semibold text-slate-900">Digitalización</p>
+                <p class="text-sm text-slate-600">Escaneo y armado de anexos</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 rounded-2xl border border-slate-200 p-4">
+              <div class="shrink-0"><i data-lucide="mouse-pointer-click" class="h-5 w-5 text-violet-600"></i></div>
+              <div>
+                <p class="font-semibold text-slate-900">Postulación online</p>
+                <p class="text-sm text-slate-600">Envío con constancia para tu respaldo</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- TRUST -->
+  <section class="py-12 sm:py-16">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div class="grid md:grid-cols-3 gap-6">
+        <div class="rounded-3xl border border-slate-200 bg-white p-6 text-center shadow-sm">
+          <p class="text-2xl font-extrabold tracking-tight text-slate-900">24h</p>
+          <p class="text-sm text-slate-600">Respuesta</p>
+        </div>
+        <div class="rounded-3xl border border-slate-200 bg-white p-6 text-center shadow-sm">
+          <p class="text-2xl font-extrabold tracking-tight text-slate-900">991 963 019</p>
+          <p class="text-sm text-slate-600">WhatsApp</p>
+        </div>
+        <div class="rounded-3xl border border-slate-200 bg-white p-6 text-center shadow-sm">
+          <p class="text-2xl font-extrabold tracking-tight text-slate-900">100%</p>
+          <p class="text-sm text-slate-600">Atención online</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- SERVICES -->
+  <section id="servicios" class="py-12 sm:py-20 bg-slate-50 border-y border-slate-200">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <h2 class="text-3xl font-bold text-slate-900 text-center">Servicios principales</h2>
+      <p class="text-slate-600 text-center mt-2">Todo lo que necesitas para postular sin estrés.</p>
+
+      <div class="mt-10 grid md:grid-cols-3 gap-6">
+        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div class="flex items-center gap-3">
+            <div class="h-10 w-10 rounded-xl bg-slate-900/90 text-white flex items-center justify-center">
+              <i data-lucide="file-text" class="h-6 w-6"></i>
+            </div>
+            <div>
+              <h3 class="font-semibold text-slate-900">Revisión de bases</h3>
+              <p class="text-sm text-slate-600">Checklist de requisitos, formatos y anexos.</p>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div class="flex items-center gap-3">
+            <div class="h-10 w-10 rounded-xl bg-slate-900/90 text-white flex items-center justify-center">
+              <i data-lucide="upload" class="h-6 w-6"></i>
+            </div>
+            <div>
+              <h3 class="font-semibold text-slate-900">Armado de expediente</h3>
+              <p class="text-sm text-slate-600">Orden de documentos, escaneo y conversión a PDF.</p>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div class="flex items-center gap-3">
+            <div class="h-10 w-10 rounded-xl bg-slate-900/90 text-white flex items-center justify-center">
+              <i data-lucide="mouse-pointer-click" class="h-6 w-6"></i>
+            </div>
+            <div>
+              <h3 class="font-semibold text-slate-900">Envío de postulación</h3>
+              <p class="text-sm text-slate-600">Registro en plataforma y constancia para tu correo/WhatsApp.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-8 flex justify-center">
+        <a href="https://wa.me/51991963019?text=Hola%20vengo%20de%20la%20web%20Postula%20F%C3%A1cil%20y%20quiero%20asesor%C3%ADa%20para%20postular" target="_blank" class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 hover:bg-slate-800 text-white px-6 py-3 shadow">
+          <i data-lucide="message-circle" class="h-5 w-5"></i>
+          Iniciar mi postulación ahora
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- HOW IT WORKS -->
+  <section id="pasos" class="py-12 sm:py-20">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div class="grid lg:grid-cols-2 gap-12 items-center">
+        <div>
+          <h2 class="text-3xl font-bold text-slate-900">¿Cómo funciona?</h2>
+          <ol class="mt-6 space-y-4 text-slate-700">
+            <li class="flex gap-3"><span class="font-semibold">1.</span> Me escribes por WhatsApp y me envías la convocatoria o enlace.</li>
+            <li class="flex gap-3"><span class="font-semibold">2.</span> Reviso requisitos y te digo qué documentos faltan.</li>
+            <li class="flex gap-3"><span class="font-semibold">3.</span> Armamos el expediente (CV + anexos) y validamos.</li>
+            <li class="flex gap-3"><span class="font-semibold">4.</span> Registro tu postulación y te entrego la constancia.</li>
+          </ol>
+          <p class="mt-6 flex items-center gap-2 text-emerald-700"><i data-lucide="shield-check" class="h-5 w-5"></i> Trabajo con <span class="font-semibold">confidencialidad</span> y <span class="font-semibold">transparencia</span>.</p>
+        </div>
+        <div class="rounded-3xl border border-slate-200 p-6 bg-white shadow-sm">
+          <form onsubmit="event.preventDefault()" class="space-y-4">
+            <h3 class="text-xl font-semibold">Déjame tus datos y te contacto</h3>
+            <label class="block">
+              <span class="text-sm font-medium text-slate-700">Nombre</span>
+              <input type="text" placeholder="Tu nombre" class="mt-1 w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-900/20" />
+            </label>
+            <label class="block">
+              <span class="text-sm font-medium text-slate-700">Convocatoria (enlace)</span>
+              <input type="text" placeholder="Pega aquí el link" class="mt-1 w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-900/20" />
+            </label>
+            <label class="block">
+              <span class="text-sm font-medium text-slate-700">WhatsApp</span>
+              <input type="text" placeholder="991 963 019" value="991 963 019" class="mt-1 w-full rounded-2xl border border-slate-300 bg-white px-4 py-2.5 text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-900/20" />
+            </label>
+            <a href="https://wa.me/51991963019?text=Hola%20vengo%20de%20la%20web%20Postula%20F%C3%A1cil%20y%20quiero%20asesor%C3%ADa%20para%20postular" target="_blank" class="w-full inline-flex justify-center rounded-2xl bg-emerald-600 hover:bg-emerald-700 text-white px-6 py-3 shadow">
+              Enviar por WhatsApp
+            </a>
+            <p class="text-xs text-slate-500">*No garantizo el puesto; garantizo tu postulación correcta.</p>
+          </form>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- FAQ -->
+  <section id="faq" class="py-12 sm:py-20 bg-slate-50 border-t border-slate-200">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <h2 class="text-3xl font-bold text-slate-900 text-center">Preguntas frecuentes</h2>
+      <div class="mt-10 grid md:grid-cols-2 gap-6">
+        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <p class="font-semibold text-slate-900">¿Trabajas solo con convocatorias del Estado?</p>
+          <p class="mt-2 text-sm text-slate-600">Trabajo con convocatorias del Estado (CAS, municipalidades, ministerios) y con privadas (colegios, empresas, ONGs).</p>
+        </div>
+        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <p class="font-semibold text-slate-900">¿Qué recibo al finalizar?</p>
+          <p class="mt-2 text-sm text-slate-600">La constancia/cargo de postulación y tu expediente digital organizado.</p>
+        </div>
+        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <p class="font-semibold text-slate-900">¿Puedo contactarte cualquier día?</p>
+          <p class="mt-2 text-sm text-slate-600">Sí, atención online. Te respondo lo antes posible por WhatsApp.</p>
+        </div>
+        <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <p class="font-semibold text-slate-900">¿Manejas mis datos de forma segura?</p>
+          <p class="mt-2 text-sm text-slate-600">Sí, tus documentos se manejan con estricta confidencialidad.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- FOOTER -->
+  <footer class="py-10">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 text-center">
+      <div class="flex flex-col items-center gap-4">
+        <a href="https://wa.me/51991963019?text=Hola%20vengo%20de%20la%20web%20Postula%20F%C3%A1cil%20y%20quiero%20asesor%C3%ADa%20para%20postular" target="_blank" class="inline-flex items-center gap-2 rounded-2xl bg-slate-900 hover:bg-slate-800 text-white px-6 py-3 shadow">
+          <i data-lucide="message-circle" class="h-5 w-5"></i> Escribir por WhatsApp (991 963 019)
+        </a>
+        <p class="text-sm text-slate-500">© 2025 Postula Fácil. Todos los derechos reservados.</p>
+      </div>
+    </div>
+  </footer>
+
+  <!-- FLOATING WHATSAPP -->
+  <a href="https://wa.me/51991963019?text=Hola%20vengo%20de%20la%20web%20Postula%20F%C3%A1cil%20y%20quiero%20asesor%C3%ADa%20para%20postular" target="_blank" class="fixed bottom-6 right-6 inline-flex items-center gap-2 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white px-5 py-3 shadow-lg">
+    <i data-lucide="message-circle" class="h-5 w-5"></i>
+    WhatsApp
+  </a>
+
+  <script>
+    lucide.createIcons();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add standalone `index.html` using Tailwind CSS and Lucide icons to replicate the landing page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7b0e1cf88333af608f5846eb965e